### PR TITLE
Increase transitTime window from 30 seconds to 10 minutes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Switched all metrics to micrometer API with prometheus actuator (except truck park).
 - Fixed tests working around the disabling of bean overriding in Spring Boot 2.1.x
 - Modification of the Test Drive certificate to allow multi domains (`localhost` and `test-drive`).
+- Increased highway patrol transitTime metric window from 30 seconds to 10 minutes.
 
 ## [6.0.2] - 2019-01-23
 ### Changed

--- a/monitoring/highway-patrol/src/main/java/com/hotels/road/highwaypatrol/MessagesMetricSet.java
+++ b/monitoring/highway-patrol/src/main/java/com/hotels/road/highwaypatrol/MessagesMetricSet.java
@@ -39,7 +39,7 @@ public class MessagesMetricSet {
 
   public MessagesMetricSet(MeterRegistry registry) {
     receiverErrors = Counter.builder("highwaypatrol-receiverErrors").register(registry);
-    transitTime = Timer.builder("highwaypatrol-transitTime").publishPercentileHistogram().register(registry);
+    transitTime = Timer.builder("highwaypatrol-transitTime").maximumExpectedValue(Duration.ofMinutes(10L)).publishPercentileHistogram().register(registry);
     onrampTime = Timer.builder("highwaypatrol-onrampTime").publishPercentileHistogram().register(registry);
     messagesCounted = Counter.builder("highwaypatrol-messagesCounted").register(registry);
 


### PR DESCRIPTION
transitTime's cap at 30 seconds makes it impossible to measure higher latencies accurately.